### PR TITLE
JUnitWrapperSuite suiteId

### DIFF
--- a/src/main/scala/org/scalatestplus/junit/JUnitWrapperSuite.scala
+++ b/src/main/scala/org/scalatestplus/junit/JUnitWrapperSuite.scala
@@ -202,4 +202,6 @@ class JUnitWrapperSuite(junitClassName: String, loader: ClassLoader) extends Sui
   override protected final def runTest(testName: String, args: Args): Status = {
         throw new UnsupportedOperationException
   }
+
+  override def suiteId: String = junitClassName
 }

--- a/src/test/scala/org/scalatestplus/junit/JUnitWrapperSuiteSuite.scala
+++ b/src/test/scala/org/scalatestplus/junit/JUnitWrapperSuiteSuite.scala
@@ -196,5 +196,12 @@ package org.scalatestplus.junit {
       assert(repA.testSucceededEvents.size === 2)
     }
 
+    test("A JUnitWrapperSuite should use the fully qualified classname of the class being wrapped as suiteId") {
+      val jRap =
+        new JUnitWrapperSuite("org.scalatestplus.junit.JHappySuite",
+                              this.getClass.getClassLoader)
+      assert(jRap.suiteId == "org.scalatestplus.junit.JHappySuite")                        
+    }
+
   }
 }


### PR DESCRIPTION
Override suiteId in JUnitWrapperSuite to use the class name of the class being wrapped.