### PR TITLE
Add method-level test filtering support to JUnitRunner

### DIFF
--- a/src/main/scala/org/scalatestplus/junit/JUnitRunner.scala
+++ b/src/main/scala/org/scalatestplus/junit/JUnitRunner.scala
@@ -22,6 +22,7 @@ import org.junit.runner.notification.Failure
 import org.junit.runner.Description
 import org.junit.runner.manipulation.{Filter => TestFilter, Filterable, NoTestsRemainException}
 
+import java.util.concurrent.ConcurrentHashMap
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
@@ -74,7 +75,7 @@ final class JUnitRunner(suiteClass: java.lang.Class[_ <: Suite]) extends org.jun
    */
   val getDescription = createDescription(suiteToRun)
 
-  private val excludedTests: mutable.Set[String] = mutable.Set()
+  private val excludedTests: mutable.Set[String] = ConcurrentHashMap.newKeySet[String]().asScala
 
   private def createDescription(suite: Suite): Description = {
     val description = Description.createSuiteDescription(suite.getClass)
@@ -104,10 +105,10 @@ final class JUnitRunner(suiteClass: java.lang.Class[_ <: Suite]) extends org.jun
       val includedTests: Set[String] = suiteToRun.testNames.diff(excludedTests)
       val testTags: Map[String, Map[String, Set[String]]] = Map(
         suiteToRun.suiteId ->
-          includedTests.map(test => test -> Set("INCLUDE")).toMap
+          includedTests.map(test => test -> Set("org.scalatest.Selected")).toMap
       )
       val filter = Filter(
-        tagsToInclude = Some(Set("INCLUDE")),
+        tagsToInclude = Some(Set("org.scalatest.Selected")),
         dynaTags = DynaTags(suiteTags = Map.empty, testTags = testTags)
       )
       // TODO: What should this Tracker be?

--- a/src/main/scala/org/scalatestplus/junit/JUnitRunner.scala
+++ b/src/main/scala/org/scalatestplus/junit/JUnitRunner.scala
@@ -139,12 +139,12 @@ final class JUnitRunner(suiteClass: java.lang.Class[_ <: Suite]) extends org.jun
 
   @throws(classOf[NoTestsRemainException])
   override def filter(filter: TestFilter): Unit = {
-    getDescription.getChildren.asScala
-      .filter(child => !filter.shouldRun(child))
-      .foreach(child => excludedTests.add(child.getMethodName))
-    if (getDescription.getChildren.isEmpty) {
-      throw new NoTestsRemainException()
-    }
+    val children = getDescription.getChildren.asScala
+    excludedTests ++= children
+      .filterNot(filter.shouldRun)
+      .map(_.getMethodName)
+
+    if (children.isEmpty) throw new NoTestsRemainException
   }
 
 }


### PR DESCRIPTION
## Description
This PR enhances the JUnitRunner by adding support for method-level test filtering. The implementation allows for more granular control over test execution by enabling filtering of individual test methods, rather than just entire test suites.

### Changes
- Added method-level filtering capability to `JUnitRunner`
- Introduced `excludedTests` tracking mechanism for filtered test methods
- Implemented filter logic using ScalaTest's tagging system

### Implementation Details
- Uses a mutable Set to track excluded test methods
- Leverages ScalaTest's DynaTags for runtime test filtering
- Properly handles empty test scenarios with NoTestsRemainException